### PR TITLE
Fixes #3: Corrected hide/show logic and addressed hmacKey security issue

### DIFF
--- a/Configuration/TypoScript/constants.typoscript
+++ b/Configuration/TypoScript/constants.typoscript
@@ -1,6 +1,6 @@
 plugin.tx_fnn_powermail_altcha {
     # cat=Powermail Altcha/option/100; type=string; label=hmacKey
-    hmacKey = K70ne+Ej;5NjJy&}09Dj~Kxr{Z
+    hmacKey = [YOUR_UNIQUE_KEY_HERE]
     # cat=Powermail Altcha/option/110; type=int+; label=max Number
     maxNumber = 999999
     # cat=Powermail Altcha/option/120; type=int+; label=Expires in seconds. If the value is 0, a challenge is valid for 24 hours.

--- a/Configuration/TypoScript/constants.typoscript
+++ b/Configuration/TypoScript/constants.typoscript
@@ -1,5 +1,6 @@
 plugin.tx_fnn_powermail_altcha {
     # cat=Powermail Altcha/option/100; type=string; label=hmacKey
+    # IMPORTANT: Replace this placeholder with a unique key for security reasons.
     hmacKey = [YOUR_UNIQUE_KEY_HERE]
     # cat=Powermail Altcha/option/110; type=int+; label=max Number
     maxNumber = 999999

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ The visitor then sees the Altcha widget. This additional validation effectively 
 ```
 plugin.tx_fnn_powermail_altcha {
     # HMAC key (random character string)
+    **IMPORTANT: For security, you must generate a unique key for your installation and replace the placeholder below.**
     hmacKey = K70ne+Ej;5NjJy&}09Dj~Kxr{Z
 
     # Maximum number for the challenge

--- a/Resources/Private/Templates/Powermail/Partials/Form/Field/AltchaSpamProtection.html
+++ b/Resources/Private/Templates/Powermail/Partials/Form/Field/AltchaSpamProtection.html
@@ -5,8 +5,8 @@
 <f:variable name="altchaConfig" value="{pa:altchaSpamProtection(settings: settings)}" />
 
 <f:variable name="widgetOptions"></f:variable>
-<f:if condition="{altchaConfig.configuration.hideLogo} === '0'"><f:variable name="widgetOptions">{widgetOptions} hidelogo</f:variable></f:if>
-<f:if condition="{altchaConfig.configuration.hideFooter} === '0'"><f:variable name="widgetOptions">{widgetOptions} hidefooter</f:variable></f:if>
+<f:if condition="{altchaConfig.configuration.hideLogo} === '1'"><f:variable name="widgetOptions">{widgetOptions} hidelogo</f:variable></f:if>
+<f:if condition="{altchaConfig.configuration.hideFooter} === '1'"><f:variable name="widgetOptions">{widgetOptions} hidefooter</f:variable></f:if>
 
 <div class="powermail_fieldwrap powermail_fieldwrap_type_altcha powermail_fieldwrap_{field.marker} {field.css} {settings.styles.framework.fieldAndLabelWrappingClasses}">
 	<div class="{settings.styles.framework.fieldWrappingClasses}">


### PR DESCRIPTION
### Fixes TypoScript configuration / documentation issues (#3)

This pull request addresses the issues identified in #3 by making the following changes:

#### 1. Corrected hide/show logic

The previous logic for `hideLogo` and `hideFooter` was inverted. `0` was used to hide the elements, which is confusing. This change corrects the logic so that a value of `1` now hides the elements, aligning with standard boolean practices.
* **Changed file:** `fnn_powermail_altcha/Resources/Private/Templates/Powermail/Partials/Form/Field/AltchaSpamProtection.html`

#### 2. Replaced hardcoded HMAC key

The `hmacKey` was hardcoded, which is a security risk. This change replaces the hardcoded value with a placeholder to force users to generate a unique key for their installation.
* **Changed file:** `fnn_powermail_altcha/Configuration/TypoScript/constants.typoscript`

#### 3. Added security documentation

Documentation was updated to warn users about the importance of generating a unique key. This was added to both the `constants.typoscript` file and the `README.md`.
* **Changed files:**
    * `fnn_powermail_altcha/Configuration/TypoScript/constants.typoscript`
    * `README.md`

**This PR resolves all points in issue #3.**